### PR TITLE
feat: `remove` command to remove dependency from the pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ would results in the target ``pom.xml`` to contain the following:
 You can also add by just specifying the artifact ID if the artifact is managed by either in the `dependencyManagement`, dependency with `import` scope,
 or managed by the parent.
 
+### Removing dependencies
+
+Dependencies can be removed from the `pom.xml` using the `remove` command.
+
+```bash
+# Remove by spefifying the groupId and artifactId
+pom remove groupId:artifactId
+
+# Remove by specifying the artifactId
+pom remove artifactId
+
+# Use the shorter alias, rm
+pom rm artifactId
+```
+
 ### Setting properties
 
 ```bash

--- a/src/main/java/com/github/andirady/pomcli/Main.java
+++ b/src/main/java/com/github/andirady/pomcli/Main.java
@@ -14,7 +14,7 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.TypeConversionException;
 
 @Command(name = "pom", subcommandsRepeatable = true, subcommands = { IdCommand.class, AddCommand.class,
-        SearchCommand.class, SetCommand.class, PlugCommand.class })
+        SearchCommand.class, SetCommand.class, PlugCommand.class, RemoveCommand.class })
 public class Main {
 
     public static void main(String[] args) {

--- a/src/main/java/com/github/andirady/pomcli/RemoveCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/RemoveCommand.java
@@ -1,0 +1,81 @@
+package com.github.andirady.pomcli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.DefaultModelReader;
+import org.apache.maven.model.io.DefaultModelWriter;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Help.Ansi;
+
+@Command(name = "remove", aliases = "rm", description = "Remove a dependency")
+public class RemoveCommand implements Runnable {
+
+    private static final Logger LOG = Logger.getLogger("remove");
+
+    @Option(names = { "-f", "--file" }, defaultValue = "pom.xml", order = 0)
+    Path pomPath;
+
+    @Parameters(arity = "1..*", paramLabel = "DEPENDENCY")
+    List<Dependency> coords;
+
+    private Model model;
+
+    @Override
+    public void run() {
+        var reader = new DefaultModelReader(null);
+        try (var is = Files.newInputStream(pomPath)) {
+            model = reader.read(is, Map.of());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        var dependencies = coords.stream().map(this::findExisting).filter(Optional::isPresent)
+                .map(Optional::orElseThrow).toList();
+        coords.stream().filter(d -> findExisting(d).isEmpty())
+                .forEach(d -> ansiPrint("@|yellow,bold " + format(d) + "|@ @|yellow is not a dependency|@"));
+
+        if (dependencies.isEmpty()) {
+            LOG.fine("No dependencies removed");
+            return;
+        }
+
+        model.getDependencies().removeIf(dependencies::contains);
+        dependencies.forEach(d -> ansiPrint("@|bold " + format(d) + "|@ removed"));
+
+        var writer = new DefaultModelWriter();
+        try (var os = Files.newOutputStream(pomPath)) {
+            writer.write(os, Map.of(), model);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Optional<Dependency> findExisting(Dependency dependency) {
+        return model.getDependencies().stream()
+                .filter(d -> d.getArtifactId().equals(dependency.getArtifactId()))
+                .filter(d -> dependency.getGroupId() instanceof String groupId ? groupId.equals(d.getGroupId()) : true)
+                .findFirst();
+    }
+
+    private String format(Dependency dependency) {
+        return (dependency.getGroupId() instanceof String g ? (g + ":") : "") + dependency.getArtifactId()
+                + (dependency.getVersion() instanceof String v ? (":" + v) : "");
+    }
+
+    private void ansiPrint(String message) {
+        System.out.println(Ansi.AUTO.string(message));
+    }
+
+}

--- a/src/main/resources/META-INF/native-image/com.github.andirady.pomcli/pomcli/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.andirady.pomcli/pomcli/reflect-config.json
@@ -59,6 +59,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
 {
+  "name":"com.github.andirady.pomcli.RemoveCommand",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
   "name":"com.github.andirady.pomcli.solrsearch.SolrSearchRequest",
   "methods":[
     {"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.lang.String","int","int"] }, 

--- a/src/test/java/com/github/andirady/pomcli/RemoveCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/RemoveCommandTest.java
@@ -1,0 +1,73 @@
+package com.github.andirady.pomcli;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import picocli.CommandLine;
+
+class RemoveCommandTest extends BaseTest {
+
+    CommandLine underTest;
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setup() {
+        var app = new Main();
+        underTest = Main.createCommandLine(app);
+    }
+
+    @Test
+    void removeNonDependency() throws IOException {
+        var pomPath = tempDir.resolve("pom.xml");
+        Files.writeString(pomPath, """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <groupId>g</groupId>
+                            <artifactId>a</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        var ec = underTest.execute("rm", "-f", pomPath.toString(), "b");
+        assertSame(0, ec);
+        var matched = evalXpath(pomPath,
+                "/project/dependencies/dependency[groupId='g' and artifactId='a' and version='1']");
+        assertSame(1, matched, "Nodes matching");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "g:a:1", "g:a", "a" })
+    void success(String coord) throws Exception {
+        var pomPath = tempDir.resolve("pom.xml");
+        Files.writeString(pomPath, """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <groupId>g</groupId>
+                            <artifactId>a</artifactId>
+                            <version>1</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        var ec = underTest.execute("rm", "-f", pomPath.toString(), coord);
+        assertSame(0, ec);
+        var matched = evalXpath(pomPath,
+                "/project/dependencies/dependency[groupId='g' and artifactId='a' and version='1']");
+        assertSame(0, matched, "Nodes matching");
+    }
+}


### PR DESCRIPTION
This patch introduce a `remove` command, with alias `rm` to allow removing dependency from the command line.
Currently this only supports removing dependency from the `/project/dependencies` path.