### PR TITLE
Adds support for Windows

### DIFF
--- a/src/main/java/com/github/andirady/pomcli/Main.java
+++ b/src/main/java/com/github/andirady/pomcli/Main.java
@@ -21,6 +21,7 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -113,16 +114,20 @@ public class Main {
     }
 
     static Dependency stringToDependency(String s) {
-        var path = Path.of(s);
-        if (Files.isRegularFile(path)) {
-            var filename = path.getFileName().toString();
-            if (filename.endsWith(".jar")) {
-                return readCoordFromJarFile(path);
-            } else if (filename.endsWith(".xml")) {
-                return readCoordFromPomFile(path);
+        try {
+            var path = Path.of(s);
+            if (Files.isRegularFile(path)) {
+                var filename = path.getFileName().toString();
+                if (filename.endsWith(".jar")) {
+                    return readCoordFromJarFile(path);
+                } else if (filename.endsWith(".xml")) {
+                    return readCoordFromPomFile(path);
+                }
+            } else if (Files.isDirectory(path)) {
+                return readCoordFromPomFile(path.resolve("pom.xml"));
             }
-        } else if (Files.isDirectory(path)) {
-            return readCoordFromPomFile(path.resolve("pom.xml"));
+        } catch (InvalidPathException ignored) {
+
         }
 
         var d = new Dependency();

--- a/src/test/java/com/github/andirady/pomcli/IdCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/IdCommandTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -237,7 +238,7 @@ class IdCommandTest extends BaseTest {
         underTest.execute("id", "-f", pomPath.toString(), ".");
         LOG.fine(Files.readString(pomPath));
 
-        var expr = "/project/parent[groupId='a' and artifactId='a' and version='1' and relativePath='../..']";
+        var expr = "/project/parent[groupId='a' and artifactId='a' and version='1' and relativePath='.." + FileSystems.getDefault().getSeparator() + "..']";
         assertXpath(pomPath, expr, 1);
         assertEquals("jar a:c:1", out.toString().trim());
     }

--- a/src/test/java/com/github/andirady/pomcli/SearchCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/SearchCommandTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.andirady.pomcli;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -79,6 +79,6 @@ class SearchCommandTest {
                 g:a:1                                                                                                    @|fg(238)     6 years ago|@""");
         var actual = out.toString();
 
-        assertEquals(expected, actual);
-	}
+        assertLinesMatch(expected.lines(), actual.lines());
+    }
 }


### PR DESCRIPTION
':' is an invalid filename character and an InvalidPathException is thrown.

fixes #23 