### PR TITLE
Unset command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@
 name: CI
 
 on:
+  pull_request:
+    branches: ["main"]
   push:
     paths:
       - '**.java'

--- a/src/main/java/com/github/andirady/pomcli/Main.java
+++ b/src/main/java/com/github/andirady/pomcli/Main.java
@@ -40,8 +40,8 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.TypeConversionException;
 
 @Command(name = "pom", subcommandsRepeatable = true, subcommands = { IdCommand.class, AddCommand.class,
-        SearchCommand.class, SetCommand.class, GetCommand.class, PlugCommand.class, RemoveCommand.class,
-        SetParentCommand.class })
+        SearchCommand.class, SetCommand.class, UnsetCommand.class, GetCommand.class, PlugCommand.class,
+        RemoveCommand.class, SetParentCommand.class })
 public class Main {
 
     public static void main(String[] args) {

--- a/src/main/java/com/github/andirady/pomcli/UnsetCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/UnsetCommand.java
@@ -1,0 +1,74 @@
+package com.github.andirady.pomcli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.DefaultModelReader;
+import org.apache.maven.model.io.DefaultModelWriter;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Spec;
+
+@Command(name = "unset")
+public class UnsetCommand implements Runnable {
+
+    @Option(names = { "-f", "--file" }, defaultValue = "pom.xml")
+    Path pomPath;
+
+    @Parameters(arity = "1")
+    String property;
+
+    @Spec
+    CommandSpec spec;
+
+    @ParentCommand
+    Main main;
+
+    @Override
+    public void run() {
+        var pomReader = new DefaultModelReader(null);
+        Model pom;
+        try (var is = Files.newInputStream(pomPath)) {
+            pom = pomReader.read(is, null);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        var profileId = main.getProfileId();
+        var propertyValue = profileId.map(id -> getPropertiesForProfile(pom, id))
+                .orElseGet(pom::getProperties)
+                .remove(property);
+
+        Objects.requireNonNull(propertyValue,
+                "No such property: " + property + profileId.map(i -> ", profile: " + i).orElse(""));
+
+        spec.commandLine().getOut().println("✅ Property `%s' unset, the value was `%s'".formatted(property, propertyValue));
+
+        var pomWriter = new DefaultModelWriter();
+        try (var out = Files.newOutputStream(pomPath)) {
+            pomWriter.write(out, Map.of(), pom);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Properties getPropertiesForProfile(Model pom, String profileId) {
+        return pom.getProfiles()
+                .stream()
+                .filter(p -> profileId.equals(p.getId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No such profile: " + profileId))
+                .getProperties();
+    }
+
+}

--- a/src/test/java/com/github/andirady/pomcli/UnsetCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/UnsetCommandTest.java
@@ -1,0 +1,133 @@
+package com.github.andirady.pomcli;
+
+import static java.nio.file.Files.writeString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import picocli.CommandLine;
+
+class UnsetCommandTest extends BaseTest {
+
+    CommandLine underTest;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setup() {
+        var app = new Main();
+        underTest = Main.createCommandLine(app);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        deleteRecursive(tempDir);
+    }
+
+    @Test
+    void shouldFailWhenPropertyDoesNotExists() throws IOException {
+        var pomPath = tempDir.resolve("pom.xml");
+        writeString(pomPath, """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>g</groupId>
+                    <artifactId>a</artifactId>
+                    <version>1</version>
+                    <properties>
+                    </properties>
+                </project>
+                """);
+
+        var result = underTest.execute("unset", "-f", pomPath.toString(), "target");
+        assertTrue(result > 0);
+    }
+
+    @Test
+    void shouldFailWhenPropertyDoesNotExistsInProfile() throws IOException {
+        var pomPath = tempDir.resolve("pom.xml");
+        writeString(pomPath, """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>g</groupId>
+                    <artifactId>a</artifactId>
+                    <version>1</version>
+                    <properties>
+                    </properties>
+                    <profiles>
+                        <profile>
+                            <id>target</id>
+                            <properties>
+                            </properties>
+                        </profile>
+                    </profiles>
+                </project>
+                """);
+
+        var result = underTest.execute("-P", "target", "unset", "-f", pomPath.toString(), "target");
+        assertTrue(result > 0);
+    }
+
+    @Test
+    void shouldRemoveFromProperties() throws IOException {
+        var pomPath = tempDir.resolve("pom.xml");
+        writeString(pomPath, """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>g</groupId>
+                    <artifactId>a</artifactId>
+                    <version>1</version>
+                    <properties>
+                        <target>foo</target>
+                    </properties>
+                </project>
+                """);
+
+        underTest.execute("unset", "-f", pomPath.toString(), "target");
+        assertXpath(pomPath, "/project/properties/target", 0);
+    }
+
+    @Test
+    void shouldRemoveFromProfileProperties() throws IOException {
+        var pomPath = tempDir.resolve("pom.xml");
+        writeString(pomPath, """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>g</groupId>
+                    <artifactId>a</artifactId>
+                    <version>1</version>
+                    <properties>
+                        <target>foo</target>
+                    </properties>
+                    <profiles>
+                        <profile>
+                            <id>target</id>
+                            <properties>
+                                <target>bar</target>
+                            </properties>
+                        </profile>
+                        <profile>
+                            <id>nontarget</id>
+                            <properties>
+                                <target>baz</target>
+                            </properties>
+                        </profile>
+                    </profiles>
+                </project>
+                """);
+
+        underTest.execute("-P", "target", "unset", "-f", pomPath.toString(), "target");
+
+        System.out.println(Files.readString(pomPath));
+        assertXpath(pomPath, "/project/properties/target", 1);
+        assertXpath(pomPath, "/project/profiles/profile[id='target']/properties/target", 0);
+        assertXpath(pomPath, "/project/profiles/profile[id='nontarget']/properties/target", 1);
+    }
+}


### PR DESCRIPTION
A new command to remove property from the `<properties>`.
Unlike `set foo=` which sets the property value to empty, the `unset` command removes the `<foo>` element.

So, if we have a `pom.xml` containing the following:
```xml
  <properties>
    <foo>bar</foo>
  </properties>
```

with `set foo=`, the result will be
```xml
  <properties>
    <foo></foo>
  </properties>
```

while with `unset foo`, the result is
```xml
  <properties></properties>
```
