### PR TITLE
fix: Don't fail if java is not installed

### DIFF
--- a/src/main/java/com/github/andirady/pomcli/GetJavaMajorVersion.java
+++ b/src/main/java/com/github/andirady/pomcli/GetJavaMajorVersion.java
@@ -17,6 +17,7 @@ package com.github.andirady.pomcli;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,7 +30,7 @@ public interface GetJavaMajorVersion {
         return ServiceLoader.load(GetJavaMajorVersion.class).findFirst().orElseThrow(); 
     }
 
-    default String get() {
+    default Optional<String> get() {
         try (
             var br = getBufferedReader();
         ) {
@@ -40,10 +41,9 @@ public interface GetJavaMajorVersion {
                      .map(m -> {
                          var i = m.group(1);
                          return "1".equals(i) ? (i + m.group(3)) : i;
-                     })
-                     .orElseThrow();
+                     });
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/com/github/andirady/pomcli/NewPom.java
+++ b/src/main/java/com/github/andirady/pomcli/NewPom.java
@@ -47,8 +47,8 @@ public class NewPom {
             parent.setArtifactId(parentPom.model().getArtifactId());
             parent.setVersion(parentPom.model().getVersion());
             var relativePath = pomPath.toAbsolutePath()
-                                      .getParent()
-                                      .relativize(parentPom.path().getParent()).toString();
+                    .getParent()
+                    .relativize(parentPom.path().getParent()).toString();
             if (!"..".equals(relativePath)) {
                 parent.setRelativePath(relativePath);
             }
@@ -59,15 +59,16 @@ public class NewPom {
             // Use UTF-8 for default encoding.
             props.setProperty("project.build.sourceEncoding", "UTF-8");
 
-            var majorVersion = GetJavaMajorVersion.getInstance().get(); 
-            if (Double.parseDouble(majorVersion) < 9) {
-                props.setProperty("maven.compiler.source", majorVersion);
-                props.setProperty("maven.compiler.target", majorVersion);
-            } else {
-                props.setProperty("maven.compiler.release", majorVersion);
+            GetJavaMajorVersion.getInstance().get().ifPresent(majorVersion -> {
+                if (Double.parseDouble(majorVersion) < 9) {
+                    props.setProperty("maven.compiler.source", majorVersion);
+                    props.setProperty("maven.compiler.target", majorVersion);
+                } else {
+                    props.setProperty("maven.compiler.release", majorVersion);
 
-                new AddPlugin().addPlugin(model, "maven-compiler-plugin");
-            }
+                    new AddPlugin().addPlugin(model, "maven-compiler-plugin");
+                }
+            });
         }
 
         model.setVersion("0.0.1-SNAPSHOT");
@@ -79,7 +80,6 @@ public class NewPom {
 
         return model;
     }
-
 
     private ParentPom findParentPom(Path pomPath, ModelReader pomReader) {
         var parent = pomPath.toAbsolutePath().getParent();


### PR DESCRIPTION
When java is not found/installed, skip setting the `maven.compiler.*` properties instead of failing.