### PR TITLE
feat(id): accept directory or jar for --file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
   <properties>
     <maven.compiler.release>24</maven.compiler.release>
     <exec.mainClass>com.github.andirady.pomcli.Main</exec.mainClass>
+    <exec.arguments>${args}</exec.arguments>
     <picocli.version>4.7.4</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <executable-suffix></executable-suffix>

--- a/src/main/java/com/github/andirady/pomcli/AddCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/AddCommand.java
@@ -82,7 +82,8 @@ public class AddCommand implements Runnable {
         }
     }
 
-    @Option(names = { "-f", "--file" }, defaultValue = "pom.xml", order = 0)
+    @Option(names = { "-f",
+            "--file" }, defaultValue = "pom.xml", order = 0, description = "Path to pom.xml. Can be a regular file or a directory")
     Path pomPath;
 
     @ArgGroup(exclusive = true, multiplicity = "0..1", order = 1)
@@ -111,6 +112,14 @@ public class AddCommand implements Runnable {
 
     @Override
     public void run() {
+        pomPath = pomPath.startsWith("~")
+                ? Path.of(System.getProperty("user.home")).resolve(pomPath.subpath(1, pomPath.getNameCount()))
+                : pomPath;
+
+        if (Files.isDirectory(pomPath)) {
+            pomPath = pomPath.resolve("pom.xml");
+        }
+
         var reader = new DefaultModelReader(null);
         if (Files.exists(pomPath)) {
             try (var is = Files.newInputStream(pomPath)) {

--- a/src/main/java/com/github/andirady/pomcli/IdCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/IdCommand.java
@@ -58,6 +58,11 @@ public class IdCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
+        if (Files.isDirectory(pomPath)) {
+            pomPath = pomPath.resolve("pom.xml");
+            return call();
+        }
+
         if (id != null) {
             updatePom();
         } else if (Files.notExists(pomPath)) {

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -515,7 +515,26 @@ class AddCommandTest extends BaseTest {
                 """);
         underTest.execute("add", "-f", pomPath.toString(), "g:a:1.0.0", "--excludes", "g:b,g:c");
         assertXpath(pomPath,
-                "/project/dependencies/dependency[groupId='g' and artifactId='a' and version='1.0.0']/exclusions/exclusion", 2);
+                "/project/dependencies/dependency[groupId='g' and artifactId='a' and version='1.0.0']/exclusions/exclusion",
+                2);
+    }
+
+    @Test
+    void shouldAcceptDirectoryAsPomPath() throws IOException {
+        var projectDir = tempDir;
+        var pomPath = projectDir.resolve("pom.xml");
+        writeString(pomPath, """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>hello-app</artifactId>
+                    <version>1.0.0</version>
+                </project>
+                """);
+        underTest.execute("add", "-f", projectDir.toString(), "g:a:1.0.0", "--excludes", "g:b,g:c");
+        assertXpath(pomPath,
+                "/project/dependencies/dependency[groupId='g' and artifactId='a' and version='1.0.0']/exclusions/exclusion",
+                2);
     }
 
     @FunctionalInterface

--- a/src/test/java/com/github/andirady/pomcli/IdCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/IdCommandTest.java
@@ -317,7 +317,21 @@ class IdCommandTest extends BaseTest {
 
         assertSame(0, ec);
         assertEquals(expected, actual);
+    }
 
+    @Test
+    void shouldAcceptDirectoryAsPomPath() {
+        var pomPath = projectPath;
+        var out = new StringWriter();
+        var underTest = new CommandLine(new Main());
+        underTest.setOut(new PrintWriter(out));
+
+        var ec = underTest.execute("id", "-f", pomPath.toString(), "g:a:v");
+        var actual = out.toString();
+
+        System.out.println(actual);
+
+        assertSame(0, ec);
     }
 
     @AfterEach

--- a/src/test/java/com/github/andirady/pomcli/IdCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/IdCommandTest.java
@@ -334,6 +334,38 @@ class IdCommandTest extends BaseTest {
         assertSame(0, ec);
     }
 
+    @Test
+    void shouldAcceptJarAsPomPath() throws IOException {
+        var pomPath = projectPath.resolve("example.jar");
+
+        try (var os = Files.newOutputStream(pomPath);
+                var jar = new java.util.jar.JarOutputStream(os)) {
+            var entry = new java.util.jar.JarEntry("META-INF/maven/g/a/pom.xml");
+            jar.putNextEntry(entry);
+            jar.write("""
+                    <project xmlns="http://maven.apache.org/POM/4.0.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>g</groupId>
+                      <artifactId>a</artifactId>
+                      <version>v</version>
+                    </project>
+                    """.getBytes());
+            jar.closeEntry();
+        }
+
+        var out = new StringWriter();
+        var underTest = new CommandLine(new Main());
+        underTest.setOut(new PrintWriter(out));
+
+        var ec = underTest.execute("id", "-f", pomPath.toString());
+        var actual = out.toString();
+
+        assertSame(0, ec);
+        assertEquals("jar g:a:v%n".formatted(), actual);
+    }
+
     @AfterEach
     void cleanup() throws IOException {
         deleteRecursive(projectPath);


### PR DESCRIPTION
The `--file` can now be a directory or a jar file. For directory, the `id` command supports reading and writing the GAV, while for jar file, it only supports reading the GAV, only if the jar contains the maven metadata.

Sample usages:
```bash
pom id -f /path/to/a-1.0.0.jar
# Outputs jar g:a:1.0.0
pom id -f /path/to/project g:a:1.0.0
# Outputs jar g:a:1.0.0
pom id -f /path/to/project
# Outputs jar g:a:1.0.0
```