### PR TITLE
feat(get): Support jar or directory for `-f` option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.16.1</version>
+      <version>5.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -115,7 +115,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.5.4</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/src/main/java/com/github/andirady/pomcli/GetCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/GetCommand.java
@@ -26,7 +26,7 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 @Command(name = "get", description = "Get properties")
-public class GetCommand extends ReadingOptions implements Runnable {
+public class GetCommand extends JarSupportedReadingOptions implements Runnable {
 
     @Parameters(arity = "1")
     String property;

--- a/src/main/java/com/github/andirady/pomcli/GetCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/GetCommand.java
@@ -15,28 +15,18 @@
  */
 package com.github.andirady.pomcli;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Objects;
 
-import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
-import org.apache.maven.model.io.DefaultModelReader;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 @Command(name = "get", description = "Get properties")
-public class GetCommand implements Runnable {
-
-    @Option(names = { "-f", "--file" }, defaultValue = "pom.xml")
-    Path pomPath;
+public class GetCommand extends ReadingOptions implements Runnable {
 
     @Parameters(arity = "1")
     String property;
@@ -49,14 +39,7 @@ public class GetCommand implements Runnable {
 
     @Override
     public void run() {
-        var pomReader = new DefaultModelReader(null);
-        Model pom;
-        try (var is = Files.newInputStream(pomPath)) {
-            pom = pomReader.read(is, null);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
+        var pom = getPom().orElseThrow(() -> new IllegalStateException(pomPath + " is not a file."));
         var profileId = main.getProfileId();
         var propertyValue = profileId.map(id -> pom.getProfiles()
                 .stream()

--- a/src/main/java/com/github/andirady/pomcli/JarSupportedReadingOptions.java
+++ b/src/main/java/com/github/andirady/pomcli/JarSupportedReadingOptions.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2021-2025 Andi Rady Kurniawan
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.andirady.pomcli;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class JarSupportedReadingOptions extends ReadingOptions {
+
+    @Override
+    protected Path getPomFilePath() {
+        if (pomPath.toString().endsWith(".jar")) {
+            try {
+                return getPomPathFromJar(pomPath);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        return super.getPomFilePath();
+    }
+
+    protected Path getPomPathFromJar(Path pomPath) throws IOException {
+        var zipfs = FileSystems.newFileSystem(pomPath);
+        return Files.walk(zipfs.getPath("META-INF", "maven"))
+                .filter(p -> p.getFileName().toString().equals("pom.xml"))
+                .filter(Files::isRegularFile)
+                .findFirst()
+                .orElseThrow(() -> new IOException("No maven metadata"));
+
+    }
+
+}

--- a/src/main/resources/META-INF/native-image/com.github.andirady.pomcli/pomcli/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.andirady.pomcli/pomcli/reflect-config.json
@@ -80,6 +80,16 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
 {
+  "name" : "com.github.andirady.pomcli.ReadingOptions",
+  "allDeclaredConstructors" : true,
+  "allPublicConstructors" : true,
+  "allDeclaredMethods" : true,
+  "allPublicMethods" : true,
+  "fields" : [
+    { "name" : "pomPath" }
+  ]
+},
+{
   "name":"com.github.andirady.pomcli.RemoveCommand",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,

--- a/src/test/java/com/github/andirady/pomcli/BaseTest.java
+++ b/src/test/java/com/github/andirady/pomcli/BaseTest.java
@@ -61,6 +61,20 @@ class BaseTest {
         }
     }
 
+    Path makeMavenJar(Path path, String content) {
+        try (var os = Files.newOutputStream(path);
+                var jar = new java.util.jar.JarOutputStream(os)) {
+            var entry = new java.util.jar.JarEntry("META-INF/maven/g/a/pom.xml");
+            jar.putNextEntry(entry);
+            jar.write(content.getBytes());
+            jar.closeEntry();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return path;
+    }
+
     private int evalXpath(Path pomPath, String expr) {
         try (var is = Files.newInputStream(pomPath)) {
             var dbf = DocumentBuilderFactory.newInstance();

--- a/src/test/java/com/github/andirady/pomcli/GetCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/GetCommandTest.java
@@ -91,6 +91,27 @@ class GetCommandTest extends BaseTest {
         assertEquals("world", out.toString().trim());
     }
 
+    @Test
+    void shouldAcceptDirectoryAsPomPath() throws IOException {
+        writeString(projectPath.resolve("pom.xml"), """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>a</groupId>
+                  <artifactId>a</artifactId>
+                  <version>1</version>
+                  <properties>
+                    <foo>hello</foo>
+                  </properties>
+                </project>
+                """);
+
+        var out = new StringWriter();
+        underTest.setOut(new PrintWriter(out));
+        underTest.execute("get", "-f", projectPath.toString(), "foo");
+
+        assertEquals("hello", out.toString().trim());
+    }
+
     @AfterEach
     void cleanup() throws IOException {
         deleteRecursive(projectPath);

--- a/src/test/java/com/github/andirady/pomcli/GetCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/GetCommandTest.java
@@ -112,6 +112,27 @@ class GetCommandTest extends BaseTest {
         assertEquals("hello", out.toString().trim());
     }
 
+    @Test
+    void shouldAcceptJarAsPomPath() throws IOException {
+        var pomPath = makeMavenJar(projectPath.resolve("example.jar"), """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>a</groupId>
+                  <artifactId>a</artifactId>
+                  <version>1</version>
+                  <properties>
+                    <foo>hello</foo>
+                  </properties>
+                </project>
+                """);
+
+        var out = new StringWriter();
+        underTest.setOut(new PrintWriter(out));
+        underTest.execute("get", "-f", pomPath.toString(), "foo");
+
+        assertEquals("hello", out.toString().trim());
+    }
+
     @AfterEach
     void cleanup() throws IOException {
         deleteRecursive(projectPath);


### PR DESCRIPTION
You can now pass a directory or a jar file that contains `pom.xml` under the `META-INF/maven` as an argument for the `-f` option.