### PR TITLE
Support default project version via POM_CLI_DEFAULT_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,18 @@ pom id com.example:.
 pom id com.example:.:1.0.0
 ```
 
-By default, if the ``group_id`` is not specified, ``unnamed`` will be used.
-To set a different default ``group_id`` you can set the ``POM_CLI_DEFAULT_GROUP_ID`` environment variable.
+By default, if the ``group_id`` is not specified, ``unnamed`` will be used,
+and if the version is not specified, ``0.0.1-SNAPSHOT`` will be used.
+To set different defaults, you can use:
+- ``POM_CLI_DEFAULT_GROUP_ID`` for ``group_id``
+- ``POM_CLI_DEFAULT_VERSION`` for version
 
 ```bash
 export POM_CLI_DEFAULT_GROUP_ID=com.example
+export POM_CLI_DEFAULT_VERSION=1.2.3-SNAPSHOT
 cd my-app
 pom id .
-# The pom will have ID com.example:my-app:0.0.1-SNAPSHOT
+# The pom will have ID com.example:my-app:1.2.3-SNAPSHOT
 ```
 
 If the current folder belongs to a multi-module maven project,

--- a/src/main/java/com/github/andirady/pomcli/Config.java
+++ b/src/main/java/com/github/andirady/pomcli/Config.java
@@ -24,4 +24,6 @@ public interface Config {
     }
 
     String getDefaultGroupId();
+
+    String getDefaultVersion();
 }

--- a/src/main/java/com/github/andirady/pomcli/NewPom.java
+++ b/src/main/java/com/github/andirady/pomcli/NewPom.java
@@ -93,11 +93,12 @@ public class NewPom {
             });
         }
 
-        model.setVersion("0.0.1-SNAPSHOT");
+        var config = Config.getInstance();
+        model.setVersion(config.getDefaultVersion());
         model.setArtifactId(pomPath.getParent().getFileName().toString());
         if (model.getParent() == null) {
-            model.setGroupId(Config.getInstance().getDefaultGroupId());
-            model.setVersion("0.0.1-SNAPSHOT");
+            model.setGroupId(config.getDefaultGroupId());
+            model.setVersion(config.getDefaultVersion());
         }
 
         return model;

--- a/src/main/java/com/github/andirady/pomcli/impl/ConfigImpl.java
+++ b/src/main/java/com/github/andirady/pomcli/impl/ConfigImpl.java
@@ -21,8 +21,13 @@ import com.github.andirady.pomcli.Config;
 
 public class ConfigImpl implements Config {
 
-	@Override
-	public String getDefaultGroupId() {
+    @Override
+    public String getDefaultGroupId() {
         return Objects.requireNonNullElse(System.getenv("POM_CLI_DEFAULT_GROUP_ID"), "unnamed");
-	}
+    }
+
+    @Override
+    public String getDefaultVersion() {
+        return Objects.requireNonNullElse(System.getenv("POM_CLI_DEFAULT_VERSION"), "0.0.1-SNAPSHOT");
+    }
 }

--- a/src/test/java/com/github/andirady/pomcli/NewPomTest.java
+++ b/src/test/java/com/github/andirady/pomcli/NewPomTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import com.github.andirady.pomcli.impl.ConfigTestImpl;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,6 +37,23 @@ class NewPomTest extends BaseTest {
         var underTest = new NewPom();
         var model = underTest.newPom(Path.of("foo", "bar", "pom.xml"), standalone);
         assertEquals("bar", model.getArtifactId());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void shouldUseConfiguredDefaultVersion(boolean standalone) {
+        if (Config.getInstance() instanceof ConfigTestImpl config) {
+            config.setDefaultVersion("1.2.3-SNAPSHOT");
+        }
+
+        var underTest = new NewPom();
+        var model = underTest.newPom(Path.of("foo", "bar", "pom.xml"), standalone);
+        assertEquals("1.2.3-SNAPSHOT", model.getVersion());
+
+        if (Config.getInstance() instanceof ConfigTestImpl config) {
+            config.setDefaultVersion(null);
+        }
     }
 
     @ParameterizedTest

--- a/src/test/java/com/github/andirady/pomcli/impl/ConfigTestImpl.java
+++ b/src/test/java/com/github/andirady/pomcli/impl/ConfigTestImpl.java
@@ -20,11 +20,17 @@ import com.github.andirady.pomcli.Config;
 public class ConfigTestImpl implements Config {
 
     private static ThreadLocal<String> defaultGroupIdTL = new ThreadLocal<>();
+    private static ThreadLocal<String> defaultVersionTL = new ThreadLocal<>();
 
     private Config actualImpl = new ConfigImpl();
 
 	public void setDefaultGroupId(String defaultGroupId) {
         defaultGroupIdTL.set(defaultGroupId);
+    }
+
+
+    public void setDefaultVersion(String defaultVersion) {
+        defaultVersionTL.set(defaultVersion);
     }
 
     @Override
@@ -35,5 +41,15 @@ public class ConfigTestImpl implements Config {
         }
 
         return defaultGroupId;
+    }
+
+    @Override
+    public String getDefaultVersion() {
+        var defaultVersion = defaultVersionTL.get();
+        if (defaultVersion == null) {
+            return actualImpl.getDefaultVersion();
+        }
+
+        return defaultVersion;
     }
 }


### PR DESCRIPTION
### Motivation
- Allow users to override the default project version from the environment, mirroring the existing `POM_CLI_DEFAULT_GROUP_ID` behavior so created POMs can use a configurable default version.

### Description
- Add `Config#getDefaultVersion()` to the `Config` interface so config covers both groupId and version defaults.
- Implement `getDefaultVersion()` in `ConfigImpl` to read `POM_CLI_DEFAULT_VERSION` with a fallback of `0.0.1-SNAPSHOT`.
- Update `NewPom` to obtain defaults from `Config.getInstance()` and use the configurable default version when creating new POMs (and for standalone/no-parent projects also use configured groupId).
- Extend `ConfigTestImpl` to support overriding the default version in tests and add a `NewPomTest` that verifies the configured default version is used, and update the `README.md` to document `POM_CLI_DEFAULT_VERSION`.

### Testing
- Attempted to run the test suite with `mvn test -q`, but the run failed in this environment due to an external Maven build extension resolution error for `kr.motd.maven:os-maven-plugin:1.7.0` so unit tests could not complete.
- Added a unit test (`NewPomTest`) that exercises configured default version behavior but it was not executed successfully due to the above Maven resolution issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61181f1a88332b393bdc526cf1dc2)