### PR TITLE
Add Docker release workflow to build and publish GHCR image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,54 @@
+name: Docker Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: 24
+          cache: maven
+
+      - name: Build native binary
+        run: mvn -Pnative -DskipTests package
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.event.release.tag_name }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Motivation
- Publish a Docker image to GHCR automatically when a GitHub release is published.  
- Ensure the native binary is built before the Docker build because the `Dockerfile` copies `target/pom-*` into the image.

### Description
- Add a new workflow at `.github/workflows/docker-release.yml` that triggers on `release` events of type `published`.  
- Build the native binary using GraalVM/Maven via `mvn -Pnative -DskipTests package` before performing the Docker build.  
- Authenticate to the container registry using the repository actor and `GITHUB_TOKEN`, generate metadata tags (`latest` and the release tag) with `docker/metadata-action`, and build/push the image with `docker/build-push-action`.

### Testing
- No CI workflow runs were executed as part of this change since it is a workflow-only addition.  
- Verified the workflow file was created and reviewed by printing the file (`sed -n ...`) and committing it to the repository (`git add -f` and `git commit`), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a618e2c3c88332ba08adc0f4a4a4a4)