### PR TITLE
chore: draft release 0.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <junit.version>5.9.3</junit.version>
     <jackson.version>2.14.1</jackson.version>
     <jdk.version>24.0.0</jdk.version>
-    <revision>0.9.7</revision>
+    <revision>0.9.8</revision>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
### Motivation
- Prepare the project for the 0.9.8 release by updating the Maven `revision` property.

### Description
- Bumped `<revision>` in `pom.xml` from `0.9.7` to `0.9.8` to reflect the new release version.

### Testing
- Ran `mvn test` which failed in this environment because Maven could not resolve the build extension `kr.motd.maven:os-maven-plugin:1.7.0` (network/resolver issue), so no unit test results were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7596c63bc83328ab220e17d6fc541)