### PR TITLE
Support reading dependency XML from stdin for `add` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ pom add /path/to/file.jar
 # Add by path to maven module
 pom add /path/to/module
 pom add /path/to/module/pom.xml
+
+# Add from stdin (single <dependency> or <dependencies> root)
+pom add <<EOF
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-api</artifactId>
+  <version>${log4j-api.version}</version>
+</dependency>
+EOF
 ```
 
 For projects that are packaged as "pom", the dependencies will be added

--- a/src/main/java/com/github/andirady/pomcli/AddCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/AddCommand.java
@@ -18,7 +18,9 @@ package com.github.andirady.pomcli;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.joining;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +28,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -86,7 +91,7 @@ public class AddCommand extends ReadingOptions implements Runnable {
     @Option(names = { "-o", "--optional" }, defaultValue = "false")
     public boolean optional;
 
-    @Parameters(arity = "1..*", paramLabel = "DEPENDENCY", description = """
+    @Parameters(arity = "0..*", paramLabel = "DEPENDENCY", description = """
             groupId:artifactId[:version] or path to either
             a directory, pom.xml, or a jar file.""")
     List<Dependency> coords;
@@ -111,6 +116,13 @@ public class AddCommand extends ReadingOptions implements Runnable {
             return new NewPom().newPom(getPomFilePath());
         });
         readParentPom(getPomReader());
+
+        if (coords == null || coords.isEmpty()) {
+            coords = readDependenciesFromStdin();
+        }
+        if (coords.isEmpty()) {
+            throw new IllegalArgumentException("No dependency provided");
+        }
 
         var existing = getExistingDependencies();
         LOG.fine("Checking for duplicates");
@@ -302,6 +314,104 @@ public class AddCommand extends ReadingOptions implements Runnable {
 
         var propKey = value.substring(2, value.length() - 1);
         return model.getProperties().getProperty(propKey);
+    }
+
+    List<Dependency> readDependenciesFromStdin() {
+        if (System.console() != null) {
+            return List.of();
+        }
+
+        var xml = readStdin();
+        if (xml.isBlank()) {
+            return List.of();
+        }
+
+        try {
+            var builder = newDocumentBuilderFactory().newDocumentBuilder();
+            var doc = builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            var root = doc.getDocumentElement();
+            if (root == null) {
+                return List.of();
+            }
+
+            var dependencies = switch (root.getTagName()) {
+                case "dependency" -> List.of(root);
+                case "dependencies" -> childElements(root, "dependency");
+                default -> throw new IllegalArgumentException("Expected <dependency> or <dependencies> input from stdin");
+            };
+
+            return dependencies.stream().map(this::toDependency).toList();
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to parse dependencies from stdin", e);
+        }
+    }
+
+    String readStdin() {
+        try {
+            return new String(spec.commandLine().getIn().readAllBytes(), StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read stdin", e);
+        }
+    }
+
+    Dependency toDependency(org.w3c.dom.Element dependencyElement) {
+        var dep = new Dependency();
+        dep.setGroupId(nodeText(dependencyElement, "groupId"));
+        dep.setArtifactId(nodeText(dependencyElement, "artifactId"));
+        dep.setVersion(nodeText(dependencyElement, "version"));
+        dep.setClassifier(nodeText(dependencyElement, "classifier"));
+        dep.setType(nodeText(dependencyElement, "type"));
+        dep.setScope(nodeText(dependencyElement, "scope"));
+
+        var optionalValue = nodeText(dependencyElement, "optional");
+        if (optionalValue != null) {
+            dep.setOptional(Boolean.parseBoolean(optionalValue));
+        }
+
+        if (dep.getArtifactId() == null) {
+            throw new IllegalArgumentException("Invalid dependency from stdin: missing artifactId");
+        }
+
+        return dep;
+    }
+
+    DocumentBuilderFactory newDocumentBuilderFactory() {
+        try {
+            var dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setExpandEntityReferences(false);
+            dbf.setXIncludeAware(false);
+            return dbf;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to initialize XML parser", e);
+        }
+    }
+
+    List<org.w3c.dom.Element> childElements(org.w3c.dom.Element parent, String tagName) {
+        var nodes = parent.getChildNodes();
+        var result = new ArrayList<org.w3c.dom.Element>();
+        for (var i = 0; i < nodes.getLength(); i++) {
+            if (nodes.item(i) instanceof org.w3c.dom.Element child && tagName.equals(child.getTagName())) {
+                result.add(child);
+            }
+        }
+
+        return result;
+    }
+
+    String nodeText(org.w3c.dom.Element parent, String tagName) {
+        var matches = childElements(parent, tagName);
+        if (matches.isEmpty()) {
+            return null;
+        }
+
+        var value = matches.get(0).getTextContent();
+        return value == null || value.isBlank() ? null : value.trim();
     }
 
 }

--- a/src/main/java/com/github/andirady/pomcli/AddCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/AddCommand.java
@@ -350,7 +350,7 @@ public class AddCommand extends ReadingOptions implements Runnable {
 
     String readStdin() {
         try {
-            return new String(spec.commandLine().getIn().readAllBytes(), StandardCharsets.UTF_8).trim();
+            return new String(System.in.readAllBytes(), StandardCharsets.UTF_8).trim();
         } catch (IOException e) {
             throw new RuntimeException("Unable to read stdin", e);
         }

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -603,15 +603,13 @@ class AddCommandTest extends BaseTest {
     @Test
     void shouldAcceptDependencyXmlFromStdin() throws Exception {
         var pomPath = tempDir.resolve("pom.xml");
-        underTest.setIn(new java.io.ByteArrayInputStream("""
+        var ec = executeWithStdin("""
                 <dependency>
                   <groupId>org.apache.logging.log4j</groupId>
                   <artifactId>log4j-api</artifactId>
                   <version>2.24.3</version>
                 </dependency>
-                """.getBytes()));
-
-        var ec = underTest.execute("add", "-f", pomPath.toString());
+                """, "add", "-f", pomPath.toString());
         assertSame(0, ec);
         assertXpath(pomPath,
                 "/project/dependencies/dependency[groupId='org.apache.logging.log4j' and artifactId='log4j-api' and version='2.24.3']",
@@ -621,7 +619,7 @@ class AddCommandTest extends BaseTest {
     @Test
     void shouldAcceptDependenciesXmlRootFromStdin() throws Exception {
         var pomPath = tempDir.resolve("pom.xml");
-        underTest.setIn(new java.io.ByteArrayInputStream("""
+        var ec = executeWithStdin("""
                 <dependencies>
                   <dependency>
                     <groupId>g</groupId>
@@ -634,9 +632,7 @@ class AddCommandTest extends BaseTest {
                     <version>2</version>
                   </dependency>
                 </dependencies>
-                """.getBytes()));
-
-        var ec = underTest.execute("add", "-f", pomPath.toString());
+                """, "add", "-f", pomPath.toString());
         assertSame(0, ec);
         assertXpath(pomPath, "/project/dependencies/dependency[artifactId='a' and version='1']", 1);
         assertXpath(pomPath, "/project/dependencies/dependency[artifactId='b' and version='2']", 1);
@@ -646,14 +642,24 @@ class AddCommandTest extends BaseTest {
     @Test
     void shouldRejectInvalidXmlRootFromStdin() {
         var pomPath = tempDir.resolve("pom.xml");
-        underTest.setIn(new java.io.ByteArrayInputStream("""
+        var ec = executeWithStdin("""
                 <project>
                   <dependencies/>
                 </project>
-                """.getBytes()));
-
-        var ec = underTest.execute("add", "-f", pomPath.toString());
+                """, "add", "-f", pomPath.toString());
         assertSame(1, ec);
+    }
+
+
+    int executeWithStdin(String input, String... args) {
+        var originalIn = System.in;
+        try {
+            System.setIn(new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            underTest = Main.createCommandLine(new Main());
+            return underTest.execute(args);
+        } finally {
+            System.setIn(originalIn);
+        }
     }
 
 }

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -599,4 +599,61 @@ class AddCommandTest extends BaseTest {
         Path apply(Path path) throws IOException;
     }
 
+
+    @Test
+    void shouldAcceptDependencyXmlFromStdin() throws Exception {
+        var pomPath = tempDir.resolve("pom.xml");
+        underTest.setIn(new java.io.ByteArrayInputStream("""
+                <dependency>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-api</artifactId>
+                  <version>2.24.3</version>
+                </dependency>
+                """.getBytes()));
+
+        var ec = underTest.execute("add", "-f", pomPath.toString());
+        assertSame(0, ec);
+        assertXpath(pomPath,
+                "/project/dependencies/dependency[groupId='org.apache.logging.log4j' and artifactId='log4j-api' and version='2.24.3']",
+                1);
+    }
+
+    @Test
+    void shouldAcceptDependenciesXmlRootFromStdin() throws Exception {
+        var pomPath = tempDir.resolve("pom.xml");
+        underTest.setIn(new java.io.ByteArrayInputStream("""
+                <dependencies>
+                  <dependency>
+                    <groupId>g</groupId>
+                    <artifactId>a</artifactId>
+                    <version>1</version>
+                  </dependency>
+                  <dependency>
+                    <groupId>g</groupId>
+                    <artifactId>b</artifactId>
+                    <version>2</version>
+                  </dependency>
+                </dependencies>
+                """.getBytes()));
+
+        var ec = underTest.execute("add", "-f", pomPath.toString());
+        assertSame(0, ec);
+        assertXpath(pomPath, "/project/dependencies/dependency[artifactId='a' and version='1']", 1);
+        assertXpath(pomPath, "/project/dependencies/dependency[artifactId='b' and version='2']", 1);
+    }
+
+
+    @Test
+    void shouldRejectInvalidXmlRootFromStdin() {
+        var pomPath = tempDir.resolve("pom.xml");
+        underTest.setIn(new java.io.ByteArrayInputStream("""
+                <project>
+                  <dependencies/>
+                </project>
+                """.getBytes()));
+
+        var ec = underTest.execute("add", "-f", pomPath.toString());
+        assertSame(1, ec);
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Allow users to pipe a `<dependency>` or `<dependencies>` XML snippet to the `add` command so dependencies can be added from stdin instead of only via CLI arguments or files.
- Document the new stdin usage pattern in `README.md` with an example using here-doc (`pom add <<EOF`).

### Description

- Change the positional parameter arity from `1..*` to `0..*` to permit no CLI dependency args and added runtime validation to error when no dependency input is provided.   
- Implement `readDependenciesFromStdin` which reads stdin and parses a single `<dependency>` or a `<dependencies>` root into `Dependency` objects using `toDependency`, `nodeText`, and `childElements` helpers.  
- Add a secure `DocumentBuilderFactory` wrapper in `newDocumentBuilderFactory` to disable DTDs and external entity processing for safe XML parsing.  
- Update `README.md` with an example demonstrating `pom add <<EOF` usage and add unit tests covering valid single dependency input, a `<dependencies>` root, and invalid XML root cases.

### Testing

- Ran the project's unit tests with `mvn test` and the test suite completed successfully.  
- Added and ran `AddCommandTest` cases `shouldAcceptDependencyXmlFromStdin`, `shouldAcceptDependenciesXmlRootFromStdin`, and `shouldRejectInvalidXmlRootFromStdin`, and all three tests passed.  
- Existing `AddCommand` related tests were executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a532af548332aeb674aeba3b0c4e)