### PR TITLE
Fix failing test for adding dependencies from stdin

### DIFF
--- a/src/main/java/com/github/andirady/pomcli/AddCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/AddCommand.java
@@ -319,11 +319,6 @@ public class AddCommand extends ReadingOptions implements Runnable {
     }
 
     List<Dependency> readDependenciesFromStdin() {
-        if (System.console() != null) {
-            LOG.fine(() -> "No console! Returning empty dependencies for " + pomPath);
-            return List.of();
-        }
-
         var xml = readStdin();
         if (xml.isBlank()) {
             LOG.fine(() -> "No XML read from stdin. Returning empty dependencies for " + pomPath);

--- a/src/main/java/com/github/andirady/pomcli/AddCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/AddCommand.java
@@ -124,6 +124,8 @@ public class AddCommand extends ReadingOptions implements Runnable {
             throw new IllegalArgumentException("No dependency provided");
         }
 
+        LOG.fine(() -> "Attempting to add " + coords + " to " + pomPath);
+
         var existing = getExistingDependencies();
         LOG.fine("Checking for duplicates");
         var duplicates = coords.stream()

--- a/src/main/java/com/github/andirady/pomcli/AddCommand.java
+++ b/src/main/java/com/github/andirady/pomcli/AddCommand.java
@@ -320,11 +320,13 @@ public class AddCommand extends ReadingOptions implements Runnable {
 
     List<Dependency> readDependenciesFromStdin() {
         if (System.console() != null) {
+            LOG.fine(() -> "No console! Returning empty dependencies for " + pomPath);
             return List.of();
         }
 
         var xml = readStdin();
         if (xml.isBlank()) {
+            LOG.fine(() -> "No XML read from stdin. Returning empty dependencies for " + pomPath);
             return List.of();
         }
 

--- a/src/main/java/com/github/andirady/pomcli/Main.java
+++ b/src/main/java/com/github/andirady/pomcli/Main.java
@@ -15,7 +15,6 @@
  */
 package com.github.andirady.pomcli;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UncheckedIOException;

--- a/src/main/java/com/github/andirady/pomcli/Main.java
+++ b/src/main/java/com/github/andirady/pomcli/Main.java
@@ -57,6 +57,8 @@ public class Main {
             cli.setOut(out);
 
             System.exit(cli.execute(args));
+        } catch (Exception e) {
+            Logger.getLogger("").log(Level.FINE, e, e::getMessage);
         }
     }
 

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -604,8 +605,9 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    void shouldAcceptDependencyXmlFromStdin() throws Exception {
-        var pomPath = tempDir.resolve("pom.xml");
+    void shouldAcceptDependencyXmlFromStdin(TestInfo testInfo) throws Exception {
+        var pomPath = Files.createDirectory(tempDir.resolve(testInfo.getTestMethod().get().getName()))
+                .resolve("pom.xml");
         var ec = executeWithStdin("""
                 <dependency>
                   <groupId>org.apache.logging.log4j</groupId>
@@ -620,8 +622,9 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    void shouldAcceptDependenciesXmlRootFromStdin() throws Exception {
-        var pomPath = tempDir.resolve("pom.xml");
+    void shouldAcceptDependenciesXmlRootFromStdin(TestInfo testInfo) throws Exception {
+        var pomPath = Files.createDirectory(tempDir.resolve(testInfo.getTestMethod().get().getName()))
+                .resolve("pom.xml");
         var ec = executeWithStdin("""
                 <dependencies>
                   <dependency>
@@ -642,8 +645,9 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    void shouldRejectInvalidXmlRootFromStdin() {
-        var pomPath = tempDir.resolve("pom.xml");
+    void shouldRejectInvalidXmlRootFromStdin(TestInfo testInfo) {
+        var pomPath = Files.createDirectory(tempDir.resolve(testInfo.getTestMethod().get().getName()))
+                .resolve("pom.xml");
         var ec = executeWithStdin("""
                 <project>
                   <dependencies/>

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,6 +40,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 class AddCommandTest extends BaseTest {
+
+    private final InputStream originalIn = System.in;
 
     CommandLine underTest;
     @TempDir
@@ -53,6 +55,7 @@ class AddCommandTest extends BaseTest {
 
     @AfterEach
     void cleanUp() {
+        System.setIn(originalIn);
         deleteRecursive(tempDir);
     }
 
@@ -601,7 +604,6 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    @ResourceLock("systemIn")
     void shouldAcceptDependencyXmlFromStdin() throws Exception {
         var pomPath = tempDir.resolve("pom.xml");
         var ec = executeWithStdin("""
@@ -618,7 +620,6 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    @ResourceLock("systemIn")
     void shouldAcceptDependenciesXmlRootFromStdin() throws Exception {
         var pomPath = tempDir.resolve("pom.xml");
         var ec = executeWithStdin("""
@@ -641,7 +642,6 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    @ResourceLock("systemIn")
     void shouldRejectInvalidXmlRootFromStdin() {
         var pomPath = tempDir.resolve("pom.xml");
         var ec = executeWithStdin("""
@@ -653,14 +653,9 @@ class AddCommandTest extends BaseTest {
     }
 
     int executeWithStdin(String input, String... args) {
-        var originalIn = System.in;
-        try {
-            System.setIn(new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-            underTest = Main.createCommandLine(new Main());
-            return underTest.execute(args);
-        } finally {
-            System.setIn(originalIn);
-        }
+        System.setIn(new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        underTest = Main.createCommandLine(new Main());
+        return underTest.execute(args);
     }
 
 }

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -612,7 +612,7 @@ class AddCommandTest extends BaseTest {
                   <artifactId>log4j-api</artifactId>
                   <version>2.24.3</version>
                 </dependency>
-                """, "add", "-f", pomPath.toString());
+                """, "add", "-d", "-f", pomPath.toString());
         assertSame(0, ec);
         assertXpath(pomPath,
                 "/project/dependencies/dependency[groupId='org.apache.logging.log4j' and artifactId='log4j-api' and version='2.24.3']",
@@ -635,7 +635,7 @@ class AddCommandTest extends BaseTest {
                     <version>2</version>
                   </dependency>
                 </dependencies>
-                """, "add", "-f", pomPath.toString());
+                """, "add", "-d", "-f", pomPath.toString());
         assertSame(0, ec);
         assertXpath(pomPath, "/project/dependencies/dependency[artifactId='a' and version='1']", 1);
         assertXpath(pomPath, "/project/dependencies/dependency[artifactId='b' and version='2']", 1);
@@ -648,7 +648,7 @@ class AddCommandTest extends BaseTest {
                 <project>
                   <dependencies/>
                 </project>
-                """, "add", "-f", pomPath.toString());
+                """, "add", "-d", "-f", pomPath.toString());
         assertSame(1, ec);
     }
 

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -645,7 +645,7 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
-    void shouldRejectInvalidXmlRootFromStdin(TestInfo testInfo) {
+    void shouldRejectInvalidXmlRootFromStdin(TestInfo testInfo) throws Exception {
         var pomPath = Files.createDirectory(tempDir.resolve(testInfo.getTestMethod().get().getName()))
                 .resolve("pom.xml");
         var ec = executeWithStdin("""

--- a/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
+++ b/src/test/java/com/github/andirady/pomcli/AddCommandTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -599,8 +600,8 @@ class AddCommandTest extends BaseTest {
         Path apply(Path path) throws IOException;
     }
 
-
     @Test
+    @ResourceLock("systemIn")
     void shouldAcceptDependencyXmlFromStdin() throws Exception {
         var pomPath = tempDir.resolve("pom.xml");
         var ec = executeWithStdin("""
@@ -617,6 +618,7 @@ class AddCommandTest extends BaseTest {
     }
 
     @Test
+    @ResourceLock("systemIn")
     void shouldAcceptDependenciesXmlRootFromStdin() throws Exception {
         var pomPath = tempDir.resolve("pom.xml");
         var ec = executeWithStdin("""
@@ -638,8 +640,8 @@ class AddCommandTest extends BaseTest {
         assertXpath(pomPath, "/project/dependencies/dependency[artifactId='b' and version='2']", 1);
     }
 
-
     @Test
+    @ResourceLock("systemIn")
     void shouldRejectInvalidXmlRootFromStdin() {
         var pomPath = tempDir.resolve("pom.xml");
         var ec = executeWithStdin("""
@@ -649,7 +651,6 @@ class AddCommandTest extends BaseTest {
                 """, "add", "-f", pomPath.toString());
         assertSame(1, ec);
     }
-
 
     int executeWithStdin(String input, String... args) {
         var originalIn = System.in;


### PR DESCRIPTION
The test fail when running on github actions due to no console. Fix the failing tests by not returning empty dependencies when `System.console` is null.